### PR TITLE
V2

### DIFF
--- a/devices/lepton/cci/cci.go
+++ b/devices/lepton/cci/cci.go
@@ -259,6 +259,14 @@ func (d *Dev) GetSerial() (uint64, error) {
 	return d.serial, nil
 }
 
+// Get the OEM part number
+func (d *Dev) GetPartNum() ([32]byte, error) {
+	var buffer [32]byte
+	if err := d.c.get(oemPartNumber, &buffer); err != nil {
+		return buffer, err
+	}
+}
+
 // GetUptime returns the uptime. Rolls over after 1193 hours.
 func (d *Dev) GetUptime() (time.Duration, error) {
 	var v internal.DurationMS

--- a/devices/lepton/cci/cci.go
+++ b/devices/lepton/cci/cci.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"log"
 	"reflect"
 	"strconv"
 	"strings"
@@ -285,8 +286,9 @@ func (d *Dev) GetCustomerPartNum() ([32]byte, error) {
 }
 
 func (d *Dev) GetTLinearEnabled() (bool, error) {
-	b := 0
+	b := uint32(0)
 	if err := d.c.get(radTLinearEnableState, &b); err != nil {
+		log.Println("Got error accessing TLinear")
 		return false, err
 	}
 	return b != 0, nil

--- a/devices/lepton/cci/cci.go
+++ b/devices/lepton/cci/cci.go
@@ -269,6 +269,7 @@ func (d *Dev) GetPartNum() ([32]byte, error) {
 	return buffer, nil
 }
 
+// Get software + dsp revision information
 func (d *Dev) GetSoftwareVersion() ([8]byte, error) {
 	var buffer [8]byte
 	if err := d.c.get(oemSoftwareRevision, &buffer); err != nil {
@@ -277,18 +278,11 @@ func (d *Dev) GetSoftwareVersion() ([8]byte, error) {
 	return buffer, nil
 }
 
-func (d *Dev) GetCustomerPartNum() ([32]byte, error) {
-	var buffer [32]byte
-	if err := d.c.get(oemCustomerPartNumber, &buffer); err != nil {
-		return buffer, err
-	}
-	return buffer, nil
-}
-
+// See if TLinear is available, and enabled.
+// If it errors, that means we are not on a radiometric lepton model.
 func (d *Dev) GetTLinearEnabled() (bool, error) {
 	b := uint32(0)
 	if err := d.c.get(radTLinearEnableState, &b); err != nil {
-		log.Println("Got error accessing TLinear")
 		return false, err
 	}
 	return b != 0, nil

--- a/devices/lepton/cci/cci.go
+++ b/devices/lepton/cci/cci.go
@@ -268,6 +268,30 @@ func (d *Dev) GetPartNum() ([32]byte, error) {
 	return buffer, nil
 }
 
+func (d *Dev) GetSoftwareVersion() ([8]byte, error) {
+	var buffer [8]byte
+	if err := d.c.get(oemSoftwareRevision, &buffer); err != nil {
+		return buffer, err
+	}
+	return buffer, nil
+}
+
+func (d *Dev) GetCustomerPartNum() ([32]byte, error) {
+	var buffer [32]byte
+	if err := d.c.get(oemCustomerPartNumber, &buffer); err != nil {
+		return buffer, err
+	}
+	return buffer, nil
+}
+
+func (d *Dev) GetTLinearEnabled() (bool, error) {
+	b := 0
+	if err := d.c.get(radTLinearEnableState, &b); err != nil {
+		return false, err
+	}
+	return b != 0, nil
+}
+
 // GetUptime returns the uptime. Rolls over after 1193 hours.
 func (d *Dev) GetUptime() (time.Duration, error) {
 	var v internal.DurationMS
@@ -619,6 +643,8 @@ const (
 	vidFocusMetricThreshold   command = 0x0314 // 2   GET/SET
 	vidFocusMetricGet         command = 0x0318 // 2   GET
 	vidVideoFreezeEnable      command = 0x0324 // 2   GET/SET
+
+	radTLinearEnableState command = 0x4EC1 // 2   GET
 )
 
 // TODO(maruel): Enable RadXXX commands.

--- a/devices/lepton/cci/cci.go
+++ b/devices/lepton/cci/cci.go
@@ -265,6 +265,7 @@ func (d *Dev) GetPartNum() ([32]byte, error) {
 	if err := d.c.get(oemPartNumber, &buffer); err != nil {
 		return buffer, err
 	}
+	return buffer, nil
 }
 
 // GetUptime returns the uptime. Rolls over after 1193 hours.

--- a/devices/lepton/cci/cci.go
+++ b/devices/lepton/cci/cci.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"log"
 	"reflect"
 	"strconv"
 	"strings"

--- a/devices/lepton/cci/cci.go
+++ b/devices/lepton/cci/cci.go
@@ -646,7 +646,7 @@ const (
 	vidFocusMetricGet         command = 0x0318 // 2   GET
 	vidVideoFreezeEnable      command = 0x0324 // 2   GET/SET
 
-	radTLinearEnableState command = 0x4EC1 // 2   GET
+	radTLinearEnableState command = 0x4EC0 // 2   GET
 )
 
 // TODO(maruel): Enable RadXXX commands.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module periph.io/x/periph
-
-go 1.13


### PR DESCRIPTION
This PR exposes some more functions:
- The OEM part number, which is a kind of configuration id
- The software and dsp revisions, which we can use to try and determine what version of the lepton module we have
- Whether or not TLinear is enabled.  It is enabled by default on radiometric lepton modules (2.5, 3.5), and trying to see if it is enabled on a lepton 3.0 gives an error, enabling us to determine reliably if we have a radiometry enabled lepton module.